### PR TITLE
feat: Adding Cancellation handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -69,6 +69,15 @@ def appointment():
                 role = data.get('role')
                 user_id = data.get('userID')
                 condition = {"=": [f"{role.lower()}_id", user_id]}
+            status = data.get('appointment_status')
+            if status != '':
+                values = status.split(' ')
+                checker = values[0].strip()
+                status = values[1].strip()
+                if condition:
+                    condition = {"and": [condition, {checker: ["appointment_status", status]}]}
+                else:
+                    condition = {checker: ["appointment_status", status]}
             columns = data.get('columns')
             if not columns:
                 columns = ["*"]
@@ -178,7 +187,7 @@ def appointment():
                 return {'statusCode': 400, 'error': 'Missing appointment_id'}
             if not patient_id:
                 return {'statusCode': 400, 'error': 'Missing patient_id'}
-            context.methods.delete(
+            context.methods.update(
                 DeletePatientAppointment(
                     condition={
                             "and": [
@@ -186,7 +195,8 @@ def appointment():
                                 {"=": ["patient_id", patient_id]}
 
                             ]
-                        }
+                        },
+                    appointment_status='cancelled'
                 )
             )
             return {'statusCode': 200, 'message': 'Successfully deleted appointment', 'appointmentId': appointment_id}

--- a/my_app_backend/hsm_appointment_manager/appointment_handler.py
+++ b/my_app_backend/hsm_appointment_manager/appointment_handler.py
@@ -27,9 +27,10 @@ class AppointmentHandler:
             values.append(value)
         return {"table": "appointments", "columns": columns, "values": values, "condition": condition, "context_method": context_method, "execution_method": execution_method}
     
-    def cancel(self, attribute, context_method, execution_method):
+    def cancel(self, attribute, update_data, context_method, execution_method):
         condition = getattr(self, attribute)
-        return {"table": "appointments", "condition": condition, "context_method": context_method, "execution_method": execution_method}
+        update_value = getattr(self, update_data)
+        return {"table": "appointments", "columns": update_data, "values": update_value, "condition": condition, "context_method": context_method, "execution_method": execution_method}
     
     def get(self, attribute, data, context_method, execution_method):
         condition = getattr(self, attribute)

--- a/my_app_backend/hsm_database/database_config.py
+++ b/my_app_backend/hsm_database/database_config.py
@@ -42,6 +42,10 @@ class DataBaseConfig:
         if not data:
             raise ValueError("Data cannot be empty")
         try:
+            if not isinstance(columns, list):
+                columns = [columns]
+            if not isinstance(data, list):
+                data = [data]
             self.database.update(table_name, columns, data, condition)
             self.logger.log("Data updated successfully")
         except Exception as e:

--- a/my_app_backend/hsm_models/custom_models.py
+++ b/my_app_backend/hsm_models/custom_models.py
@@ -33,8 +33,9 @@ def get_obj_config():
             "parent_method": appt_sched.AppointmentHandler.cancel,
             "kwargs": {
                 "attribute": "condition",
+                "update_data": "appointment_status",
                 "context_method": "database",
-                "execution_method": "delete"
+                "execution_method": "update",
             }
         },
         "GetPatientAppointments": {

--- a/my_app_backend/hsm_models/patient.py
+++ b/my_app_backend/hsm_models/patient.py
@@ -60,6 +60,7 @@ class UpdatePatientAppointment(BaseModel):
     
 class DeletePatientAppointment(BaseModel):
     condition: Optional[Dict] = None
+    appointment_status: Optional[Literal['cancelled']] = 'cancelled'
     
 class GetPatientAppointments(BaseModel):
     columns: Optional[List] = None


### PR DESCRIPTION
## Summary by Sourcery

Enable soft cancellation of appointments by updating the appointment_status field to 'cancelled' and introduce filtering by status in the appointment API

New Features:
- Add appointment_status query parameter to filter appointments
- Implement soft cancellation by updating appointments status to 'cancelled' instead of deleting

Enhancements:
- Refactor appointment cancellation flow to use update operations
- Extend cancel method in appointment handler to accept update data and build update payload
- Normalize columns and data inputs in database update method to support single values
- Update model configurations and schemas to include appointment_status for delete operations